### PR TITLE
Fix reject_nested_columns to consider parentheses and brackets

### DIFF
--- a/lib/hamlit/compilers/old_attribute.rb
+++ b/lib/hamlit/compilers/old_attribute.rb
@@ -136,12 +136,16 @@ module Hamlit
       end
 
       def reject_nested_columns(str, columns)
-        result     = []
+        result = []
         open_count = 0
-        emb_count  = 0
+        count = {
+          emb:     0,
+          paren:   0,
+          bracket: 0,
+        }
 
         Ripper.lex(str).each do |(row, col), type, str|
-          if columns.include?(col) && open_count == 1 && emb_count == 0
+          if columns.include?(col) && open_count == 1 && count.values.all?(&:zero?)
             result << col
           end
 
@@ -151,9 +155,17 @@ module Hamlit
           when :on_rbrace
             open_count -= 1
           when :on_embexpr_beg
-            emb_count += 1
+            count[:emb] += 1
           when :on_embexpr_end
-            emb_count -= 1
+            count[:emb] -= 1
+          when :on_lparen
+            count[:paren] += 1
+          when :on_rparen
+            count[:paren] -= 1
+          when :on_lbracket
+            count[:bracket] += 1
+          when :on_rbracket
+            count[:bracket] -= 1
           end
         end
         result

--- a/spec/rails/app/views/users/old_attributes.html.haml
+++ b/spec/rails/app/views/users/old_attributes.html.haml
@@ -1,3 +1,5 @@
 %a{ value: "#{I18n.t "foo", count: 1}" }
 %span{ data: { value: "#{I18n.t "foo", count: 2}" } }
 .foo{ data: { value: "#{I18n.t "foo", count: 3}"}}
+%a{ data: { value: t('foo', count: 4) } }
+%a{ data: { value: [count: 1] } }

--- a/spec/rails/spec/hamlit_spec.rb
+++ b/spec/rails/spec/hamlit_spec.rb
@@ -30,7 +30,7 @@ describe 'Hamlit rails integration', type: :request do
     expect(response.body).to include("<span data-value='foo 2'></span>")
     expect(response.body).to include("<div class='foo' data-value='foo 3'></div>")
     expect(response.body).to include("<a data-value='foo 4'></a>")
-    expect(response.body).to include("<a data-value='{:count=>1}'></a>")
+    expect(response.body).to include("<a data-value='[{:count=>1}]'></a>")
   end
 
   describe 'escaping' do

--- a/spec/rails/spec/hamlit_spec.rb
+++ b/spec/rails/spec/hamlit_spec.rb
@@ -29,6 +29,8 @@ describe 'Hamlit rails integration', type: :request do
     expect(response.body).to include("<a value='foo 1'></a>")
     expect(response.body).to include("<span data-value='foo 2'></span>")
     expect(response.body).to include("<div class='foo' data-value='foo 3'></div>")
+    expect(response.body).to include("<a data-value='foo 4'></a>")
+    expect(response.body).to include("<a data-value='{:count=>1}'></a>")
   end
 
   describe 'escaping' do


### PR DESCRIPTION
### Input

```haml
%a{ data: { value: t('foo', count: 1) } }
%a{ data: { value: [count: 1] } }
```

### Compiled result

```
in ~/Develop/creasty/hamlit on fix_attributes_parse_error *
❯ be hamlit parse tmp/in.haml
[:multi,
 [:html,
  :tag,
  "a",
  [:haml, :attrs, "{ data: { value: t('foo', count: 1) } }"],
  [:multi]],
 [:newline],
 [:static, "\n"],
 [:html,
  :tag,
  "a",
  [:haml, :attrs, "{ data: { value: [count: 1] } }"],
  [:multi]],
 [:newline],
 [:static, "\n"]]

in ~/Develop/creasty/hamlit on fix_attributes_parse_error *
❯ be hamlit compile tmp/in.haml
_buf = []; _buf << ("<a data-value='".freeze); _buf << (t('foo', count: 1); _buf << ("'></a>\n<a data-value='".freeze);
; _buf << ([count: 1); _buf << ("'></a>\n".freeze);
; _buf = _buf.join

in ~/Develop/creasty/hamlit on fix_attributes_parse_error *
❯ be hamlit render tmp/in.haml
/Users/ykiwng/Develop/creasty/hamlit/lib/hamlit/cli.rb:11:in `eval': (eval):2: syntax error, unexpected ')', expecting ']' (SyntaxError)
; _buf << ([count: 1); _buf << ("'></a>\n".freeze);
                     ^
(eval):3: syntax error, unexpected end-of-input, expecting ')'
; _buf = _buf.join
                  ^
	from /Users/ykiwng/Develop/creasty/hamlit/lib/hamlit/cli.rb:11:in `render'
	from /Users/ykiwng/Develop/creasty/hamlit/vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /Users/ykiwng/Develop/creasty/hamlit/vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/ykiwng/Develop/creasty/hamlit/vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /Users/ykiwng/Develop/creasty/hamlit/vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from /Users/ykiwng/Develop/creasty/hamlit/bin/hamlit:6:in `<top (required)>'
	from /Users/ykiwng/Develop/creasty/hamlit/vendor/bundle/ruby/2.2.0/bin/hamlit:23:in `load'
	from /Users/ykiwng/Develop/creasty/hamlit/vendor/bundle/ruby/2.2.0/bin/hamlit:23:in `<main>'
```

Look at the compiled result, here's a missing closing paren:

```
_buf << (t('foo', count: 1); _buf << ("'></a>\n<a data-value='".freeze);
                           ^
```

and a bracket also causes the error:

```
; _buf << ([count: 1); _buf << ("'></a>\n".freeze);
                     ^
```