### PR TITLE
Use escape_utils for Temple::Utils.escape_html

### DIFF
--- a/hamlit.gemspec
+++ b/hamlit.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "escape_utils"
   spec.add_dependency "temple", "~> 0.7.3"
   spec.add_dependency "thor"
   spec.add_dependency "tilt"

--- a/lib/hamlit/compiler.rb
+++ b/lib/hamlit/compiler.rb
@@ -1,7 +1,6 @@
 require 'hamlit/compilers/attributes'
 require 'hamlit/compilers/comment'
 require 'hamlit/compilers/doctype'
-require 'hamlit/compilers/dynamic'
 require 'hamlit/compilers/filter'
 require 'hamlit/compilers/script'
 require 'hamlit/compilers/strip'
@@ -13,7 +12,6 @@ module Hamlit
     include Compilers::Attributes
     include Compilers::Comment
     include Compilers::Doctype
-    include Compilers::Dynamic
     include Compilers::Filter
     include Compilers::Script
     include Compilers::Strip

--- a/lib/hamlit/compilers/dynamic.rb
+++ b/lib/hamlit/compilers/dynamic.rb
@@ -1,9 +1,0 @@
-module Hamlit
-  module Compilers
-    module Dynamic
-      def on_dynamic(exp)
-        [:dynamic, "(#{exp}).to_s"]
-      end
-    end
-  end
-end

--- a/lib/hamlit/engine.rb
+++ b/lib/hamlit/engine.rb
@@ -2,6 +2,7 @@ require 'temple'
 require 'hamlit/compiler'
 require 'hamlit/html'
 require 'hamlit/parser'
+require 'hamlit/temple'
 
 module Hamlit
   class Engine < Temple::Engine

--- a/lib/hamlit/temple.rb
+++ b/lib/hamlit/temple.rb
@@ -1,0 +1,9 @@
+module Hamlit
+  module TempleUtilsExtension
+    def escape_html_safe(html)
+      super(html.to_s)
+    end
+  end
+end
+
+Temple::Utils.send(:extend, Hamlit::TempleUtilsExtension)


### PR DESCRIPTION
- Add [escape_utils](https://github.com/brianmario/escape_utils) as dependency
- Reduce unnecessary `to_s` call