### PR TITLE
Allow hyphenated HTML-style attributes

### DIFF
--- a/lib/hamlit/compilers/new_attribute.rb
+++ b/lib/hamlit/compilers/new_attribute.rb
@@ -44,6 +44,15 @@ module Hamlit
       def read_key!(tokens)
         skip_tokens!(tokens, :on_sp, :on_nl, :on_ignored_nl)
         (row, col), type, key = tokens.shift
+
+        while tokens.any? && tokens.first[2] == '-'
+          tokens.shift
+
+          (row, col), type, part = tokens.shift
+
+          key = "#{key}-#{part}"
+        end
+
         key
       end
 

--- a/spec/hamlit/engine/new_attribute_spec.rb
+++ b/spec/hamlit/engine/new_attribute_spec.rb
@@ -27,6 +27,22 @@ describe Hamlit::Engine do
       HTML
     end
 
+    it 'renders hyphenated attributes properly' do
+      assert_render(<<-HAML, <<-HTML)
+        %p(data-foo='bar') bar
+      HAML
+        <p data-foo='bar'>bar</p>
+      HTML
+    end
+
+    it 'renders multiply hyphenated attributes properly' do
+      assert_render(<<-HAML, <<-HTML)
+        %p(data-x-foo='bar') bar
+      HAML
+        <p data-x-foo='bar'>bar</p>
+      HTML
+    end
+
     describe 'html escape' do
       it 'escapes attribute values on static attributes' do
         assert_render(<<-'HAML', <<-HTML, compatible_only: :faml)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'unindent'
-require 'pry'
 require_relative 'spec_helper/document_generator'
 require_relative 'spec_helper/render_helper'
 require_relative 'spec_helper/test_case'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'unindent'
+require 'pry'
 require_relative 'spec_helper/document_generator'
 require_relative 'spec_helper/render_helper'
 require_relative 'spec_helper/test_case'


### PR DESCRIPTION
I came across this when trying to use hamlit with angular. It currently parses all parts but the last of a hyphenated attribute as separate atomic attributes.