### PR TITLE
fix error when autoclose option is nil

### DIFF
--- a/lib/hamlit/compiler/tag_compiler.rb
+++ b/lib/hamlit/compiler/tag_compiler.rb
@@ -61,7 +61,7 @@ module Hamlit
       end
 
       def self_closing?(node)
-        return true if @autoclose.include?(node.value[:name])
+        return true if @autoclose && @autoclose.include?(node.value[:name])
         node.value[:self_closing]
       end
     end


### PR DESCRIPTION
This fix following problem.

```
$ ruby -S -Ilib ./exe/hamlit temple benchmark/dynamic_attributes/boolean_attribute.haml

./lib/hamlit/compiler/tag_compiler.rb:64:in `self_closing?': undefined method `include?' for nil:NilClass (NoMethodError)
Did you mean?  @autoclose
        from lib/hamlit/compiler/tag_compiler.rb:26:in `compile_contents'
        from lib/hamlit/compiler/tag_compiler.rb:16:in `compile'
        from lib/hamlit/compiler.rb:86:in `compile_tag'
        from lib/hamlit/compiler.rb:49:in `compile'
        from lib/hamlit/compiler.rb:58:in `block in compile_children'
        from lib/hamlit/compiler/children_compiler.rb:16:in `block in compile'
        from lib/hamlit/compiler/children_compiler.rb:13:in `each'
        from lib/hamlit/compiler/children_compiler.rb:13:in `compile'
        from lib/hamlit/compiler.rb:58:in `compile_children'
        from lib/hamlit/compiler.rb:35:in `compile'
        from lib/hamlit/compiler.rb:25:in `call'
        from lib/hamlit/cli.rb:58:in `generate_temple'
        from lib/hamlit/cli.rb:20:in `temple'
```

        

