### PR TITLE
make benchmark to more accurate.

### DIFF
--- a/benchmark/ext/build_data.rb
+++ b/benchmark/ext/build_data.rb
@@ -9,7 +9,9 @@ require_relative '../utils/benchmark_ips_extension'
 h = { 'user' => { id: 1234, name: 'k0kubun' }, book_id: 5432 }
 
 Benchmark.ips do |x|
-  x.report("Faml::AB.build")    { Faml::AttributeBuilder.build("'", true, nil, data: h) }
-  x.report("Hamlit.build_data") { Hamlit::AttributeBuilder.build_data(true, "'", h) }
+  quote = "'"
+  faml_options = { data: h }
+  x.report("Faml::AB.build")    { Faml::AttributeBuilder.build(quote, true, nil, faml_options) }
+  x.report("Hamlit.build_data") { Hamlit::AttributeBuilder.build_data(true, quote, h) }
   x.compare!
 end


### PR DESCRIPTION
benchmark/ext/build_data.rb

Both benchmark includes string allocation.
Faml::AttributeBuilder includes hash building.
(It maybe fair to include hash building for Faml::AttributeBuilder considering real world situation.)

But this benchmark's interest is pure speed between Faml::AttributeBuilder.build and Hamlit::AttributeBuilder.build_data. So it may be more acurate by removing that code.

BEFORE
```
Calculating -------------------------------------
      Faml::AB.build    10.567k i/100ms
   Hamlit.build_data    10.125k i/100ms
-------------------------------------------------
      Faml::AB.build    165.685k i/s (0.006ms) -    834.793k
   Hamlit.build_data    153.934k i/s (0.006ms) -    769.500k

Comparison:
      Faml::AB.build:   165684.7 i/s (0.006ms)
   Hamlit.build_data:   153933.8 i/s (0.006ms) - 1.08x slower
```

AFTER
```
Calculating -------------------------------------
      Faml::AB.build    11.028k i/100ms
   Hamlit.build_data    10.134k i/100ms
-------------------------------------------------
      Faml::AB.build    182.088k i/s (0.005ms) -    915.324k
   Hamlit.build_data    156.376k i/s (0.006ms) -    790.452k

Comparison:
      Faml::AB.build:   182088.4 i/s (0.005ms)
   Hamlit.build_data:   156376.3 i/s (0.006ms) - 1.16x slower

```