### PR TITLE
Remove escape_utils dependency

### DIFF
--- a/hamlit.gemspec
+++ b/hamlit.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.extensions    = ['ext/hamlit/extconf.rb']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'escape_utils'
   spec.add_dependency 'temple', '~> 0.7.6'
   spec.add_dependency 'thor'
   spec.add_dependency 'tilt'


### PR DESCRIPTION
Hamlit uses own Hamlit::Utils.escape_html, not
Temple::Utils.escape_html.