### PR TITLE
Fix rendering failure for static integer

### DIFF
--- a/lib/hamlit/compiler/attribute_compiler.rb
+++ b/lib/hamlit/compiler/attribute_compiler.rb
@@ -61,7 +61,7 @@ module Hamlit
       def compile_id!(temple, key, values)
         build_code = attribute_builder(:id, values)
         if values.all? { |type, exp| type == :static || StaticAnalyzer.static?(exp) }
-          temple << [:html, :attr, key, [:static, eval(build_code)]]
+          temple << [:html, :attr, key, [:static, eval(build_code).to_s]]
         else
           temple << [:html, :attr, key, [:dynamic, build_code]]
         end
@@ -70,7 +70,7 @@ module Hamlit
       def compile_class!(temple, key, values)
         build_code = attribute_builder(:class, values)
         if values.all? { |type, exp| type == :static || StaticAnalyzer.static?(exp) }
-          temple << [:html, :attr, key, [:static, eval(build_code)]]
+          temple << [:html, :attr, key, [:static, eval(build_code).to_s]]
         else
           temple << [:html, :attr, key, [:dynamic, build_code]]
         end
@@ -81,7 +81,7 @@ module Hamlit
         build_code = "::Hamlit::AttributeBuilder.build_data(#{args.join(', ')})"
 
         if values.all? { |type, exp| type == :static || StaticAnalyzer.static?(exp) }
-          temple << [:static, eval(build_code)]
+          temple << [:static, eval(build_code).to_s]
         else
           temple << [:dynamic, build_code]
         end
@@ -95,7 +95,7 @@ module Hamlit
           case value
           when true then temple << [:html, :attr, key, @format == :xhtml ? [:static, key] : [:multi]]
           when false, nil
-          else temple << [:html, :attr, key, [:escape, @escape_attrs, [:static, value]]]
+          else temple << [:html, :attr, key, [:escape, @escape_attrs, [:static, value.to_s]]]
           end
         else
           var = @identity.generate

--- a/test/hamlit/engine/attributes_test.rb
+++ b/test/hamlit/engine/attributes_test.rb
@@ -9,6 +9,7 @@ describe Hamlit::Engine do
       it { assert_haml(%q|#a{ id: false }|) }
       it { assert_haml(%q|#a{ id: 'b' }|) }
       it { assert_haml(%q|#b{ id: 'a' }|) }
+      it { assert_haml(%q|%a{ 'id' => 60 }|) }
 
       it { assert_haml(%q|#a{ id: 'b' }(id=id)|,       locals: { id: 'c' }) }
       it { assert_haml(%q|#c{ id: a = 'a' }(id=id)|,   locals: { id: 'b' }) }
@@ -54,6 +55,7 @@ describe Hamlit::Engine do
       it { assert_haml(%q|.a{ class: [] }|) }
       it { assert_haml(%q|.a{ class: %w[c b] }|) }
       it { assert_haml(%q|.a.c(class='b')|) }
+      it { assert_haml(%q|%a{ 'class' => 60 }|) }
 
       it { assert_haml(%q|%div{ class: 'b a' }(class=klass)|, locals: { klass: 'b a' }) }
       it { assert_haml(%q|%div(class=klass){ class: 'b a' }|, locals: { klass: 'b a' }) }
@@ -120,6 +122,7 @@ describe Hamlit::Engine do
     it { assert_haml(%q|%a{ data: { nil => 3 } }|) }
     it { assert_haml(%q|%a{ data: 3 }|) }
     it { assert_haml(%q|%a(data=3)|) }
+    it { assert_haml(%q|%a{ 'data-bar' => 60 }|) }
 
     it { assert_haml(%q|%a{ data: { overlay_modal: 'foo' } }|) }
     it { assert_haml(%q|%a{ data: { overlay_modal: true } }|) }
@@ -199,6 +202,8 @@ describe Hamlit::Engine do
 
     it { assert_haml(%q|%a{ hash }|, locals: { hash: { 'data-overlay_modal' => false } }) }
     it { assert_haml(%q|%a{ hash }|, locals: { hash: { 'data-overlay_modal' => true } }) }
+
+    it { assert_haml(%q|%a{ 'disabled' => 60 }|) }
   end
 
   describe 'common attributes' do
@@ -224,6 +229,7 @@ describe Hamlit::Engine do
           %div{ h }
         HAML
       end
+      it { assert_haml(%q|%a{ 'href' => 60 }|) }
     end
 
     describe 'incompatibility' do


### PR DESCRIPTION
Fixing the issue:

```html
# input
%div{ id: 60 }

# output
<div id='<'>
```

In Temple, `value` of `[:static, value]` must be `String`. With `String#concat` in `Temple::Filters::StaticMerger`, `Fixnum`(`60`) is converted to `"<"` like `#chr`.