### PR TITLE
Extract StringSplitter to Temple filter 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/). This change log is
 ### Added
 
 - Optimize inline script inside a tag
+- Optimize string interpolation recursively
 
 ## [2.1.2](https://github.com/k0kubun/hamlit/compare/v2.1.1...v2.1.2) - 2015-12-16
 

--- a/lib/hamlit/attribute_compiler.rb
+++ b/lib/hamlit/attribute_compiler.rb
@@ -2,7 +2,7 @@ require 'hamlit/attribute_builder'
 require 'hamlit/attribute_parser'
 require 'hamlit/ruby_expression'
 require 'hamlit/static_analyzer'
-require 'hamlit/string_interpolation'
+require 'hamlit/string_splitter'
 
 module Hamlit
   class AttributeCompiler
@@ -113,7 +113,7 @@ module Hamlit
       case
       when type == :dynamic && RubyExpression.string_literal?(exp)
         value_temple = [:multi]
-        StringInterpolation.compile(exp).each do |type, v|
+        StringSplitter.compile(exp).each do |type, v|
           case type
           when :static
             value_temple << [:escape, @escape_attrs, [:static, v]]

--- a/lib/hamlit/attribute_compiler.rb
+++ b/lib/hamlit/attribute_compiler.rb
@@ -2,7 +2,6 @@ require 'hamlit/attribute_builder'
 require 'hamlit/attribute_parser'
 require 'hamlit/ruby_expression'
 require 'hamlit/static_analyzer'
-require 'hamlit/string_splitter'
 
 module Hamlit
   class AttributeCompiler
@@ -108,23 +107,7 @@ module Hamlit
     end
 
     def compile_common!(temple, key, values)
-      type, exp = values.last
-
-      case
-      when type == :dynamic && RubyExpression.string_literal?(exp)
-        value_temple = [:multi]
-        StringSplitter.compile(exp).each do |type, v|
-          case type
-          when :static
-            value_temple << [:escape, @escape_attrs, [:static, v]]
-          when :dynamic
-            value_temple << [:escape, @escape_attrs, [:dynamic, v]]
-          end
-        end
-        temple << [:html, :attr, key, value_temple]
-      else
-        temple << [:html, :attr, key, [:escape, @escape_attrs, [type, exp]]]
-      end
+      temple << [:html, :attr, key, [:escape, @escape_attrs, values.last]]
     end
 
     def attribute_builder(type, values)

--- a/lib/hamlit/compiler/script_compiler.rb
+++ b/lib/hamlit/compiler/script_compiler.rb
@@ -1,6 +1,6 @@
 require 'hamlit/ruby_expression'
 require 'hamlit/static_analyzer'
-require 'hamlit/string_interpolation'
+require 'hamlit/string_splitter'
 
 module Hamlit
   class Compiler
@@ -25,7 +25,7 @@ module Hamlit
       # String-interpolated plain text must be compiled with this method
       def string_compile(node)
         temple = [:multi]
-        StringInterpolation.compile(node.value[:text]).each do |type, value|
+        StringSplitter.compile(node.value[:text]).each do |type, value|
           case type
           when :static
             value = Hamlit::Utils.escape_html(value) if node.value[:escape_html]

--- a/lib/hamlit/compiler/tag_compiler.rb
+++ b/lib/hamlit/compiler/tag_compiler.rb
@@ -1,7 +1,7 @@
 require 'hamlit/parser/haml_util'
 require 'hamlit/attribute_compiler'
 require 'hamlit/static_analyzer'
-require 'hamlit/string_interpolation'
+require 'hamlit/string_splitter'
 
 module Hamlit
   class Compiler
@@ -44,7 +44,7 @@ module Hamlit
 
       def compile_string(node)
         temple = [:multi]
-        StringInterpolation.compile(node.value[:value]).each do |type, value|
+        StringSplitter.compile(node.value[:value]).each do |type, value|
           case type
           when :static
             value = Hamlit::Utils.escape_html(value) if node.value[:escape_html]

--- a/lib/hamlit/engine.rb
+++ b/lib/hamlit/engine.rb
@@ -3,6 +3,7 @@ require 'hamlit/parser'
 require 'hamlit/compiler'
 require 'hamlit/escapable'
 require 'hamlit/html'
+require 'hamlit/string_splitter'
 require 'hamlit/static_analyzer'
 
 module Hamlit
@@ -22,6 +23,7 @@ module Hamlit
     use Parser
     use Compiler
     use HTML
+    use StringSplitter
     use StaticAnalyzer
     use Escapable
     filter :ControlFlow

--- a/lib/hamlit/string_splitter.rb
+++ b/lib/hamlit/string_splitter.rb
@@ -79,7 +79,7 @@ module Hamlit
         when :static
           temple << [:static, content]
         when :dynamic
-          temple << [:dynamic, content]
+          temple << on_dynamic(content)
         end
       end
       temple

--- a/lib/hamlit/string_splitter.rb
+++ b/lib/hamlit/string_splitter.rb
@@ -1,69 +1,88 @@
 require 'ripper'
+require 'hamlit/ruby_expression'
 
-module Hamlit::StringSplitter
-  class << self
-    # `code` param must be valid string literal
-    def compile(code)
-      [].tap do |exps|
-        tokens = Ripper.lex(code.strip)
-        tokens.pop while tokens.last && %i[on_comment on_sp].include?(tokens.last[1])
+module Hamlit
+  class StringSplitter < Temple::Filter
+    class << self
+      # `code` param must be valid string literal
+      def compile(code)
+        [].tap do |exps|
+          tokens = Ripper.lex(code.strip)
+          tokens.pop while tokens.last && %i[on_comment on_sp].include?(tokens.last[1])
 
-        if tokens.size < 2
-          raise Hamlit::InternalError.new("Expected token size >= 2 but got: #{tokens.size}")
-        end
-        compile_tokens!(exps, tokens)
-      end
-    end
-
-    private
-
-    def strip_quotes!(tokens)
-      _, type, beg_str = tokens.shift
-      if type != :on_tstring_beg
-        raise Hamlit::InternalError.new("Expected :on_tstring_beg but got: #{type}")
-      end
-
-      _, type, end_str = tokens.pop
-      if type != :on_tstring_end
-        raise Hamlit::InternalError.new("Expected :on_tstring_end but got: #{type}")
-      end
-
-      [beg_str, end_str]
-    end
-
-    def compile_tokens!(exps, tokens)
-      beg_str, end_str = strip_quotes!(tokens)
-
-      until tokens.empty?
-        _, type, str = tokens.shift
-
-        case type
-        when :on_tstring_content
-          exps << [:static, eval("#{beg_str}#{str}#{end_str}")]
-        when :on_embexpr_beg
-          embedded = shift_balanced_embexpr(tokens)
-          exps << [:dynamic, embedded] unless embedded.empty?
+          if tokens.size < 2
+            raise Hamlit::InternalError.new("Expected token size >= 2 but got: #{tokens.size}")
+          end
+          compile_tokens!(exps, tokens)
         end
       end
-    end
 
-    def shift_balanced_embexpr(tokens)
-      String.new.tap do |embedded|
-        embexpr_open = 1
+      private
+
+      def strip_quotes!(tokens)
+        _, type, beg_str = tokens.shift
+        if type != :on_tstring_beg
+          raise Hamlit::InternalError.new("Expected :on_tstring_beg but got: #{type}")
+        end
+
+        _, type, end_str = tokens.pop
+        if type != :on_tstring_end
+          raise Hamlit::InternalError.new("Expected :on_tstring_end but got: #{type}")
+        end
+
+        [beg_str, end_str]
+      end
+
+      def compile_tokens!(exps, tokens)
+        beg_str, end_str = strip_quotes!(tokens)
 
         until tokens.empty?
           _, type, str = tokens.shift
-          case type
-          when :on_embexpr_beg
-            embexpr_open += 1
-          when :on_embexpr_end
-            embexpr_open -= 1
-            break if embexpr_open == 0
-          end
 
-          embedded << str
+          case type
+          when :on_tstring_content
+            exps << [:static, eval("#{beg_str}#{str}#{end_str}")]
+          when :on_embexpr_beg
+            embedded = shift_balanced_embexpr(tokens)
+            exps << [:dynamic, embedded] unless embedded.empty?
+          end
         end
       end
+
+      def shift_balanced_embexpr(tokens)
+        String.new.tap do |embedded|
+          embexpr_open = 1
+
+          until tokens.empty?
+            _, type, str = tokens.shift
+            case type
+            when :on_embexpr_beg
+              embexpr_open += 1
+            when :on_embexpr_end
+              embexpr_open -= 1
+              break if embexpr_open == 0
+            end
+
+            embedded << str
+          end
+        end
+      end
+    end
+
+    def on_dynamic(code)
+      return [:dynamic, code] unless RubyExpression.string_literal?(code)
+      return [:dynamic, code] if code.include?("\n")
+
+      temple = [:multi]
+      StringSplitter.compile(code).each do |type, content|
+        case type
+        when :static
+          temple << [:static, content]
+        when :dynamic
+          temple << [:dynamic, content]
+        end
+      end
+      temple
     end
   end
 end

--- a/lib/hamlit/string_splitter.rb
+++ b/lib/hamlit/string_splitter.rb
@@ -1,6 +1,6 @@
 require 'ripper'
 
-module Hamlit::StringInterpolation
+module Hamlit::StringSplitter
   class << self
     # `code` param must be valid string literal
     def compile(code)

--- a/test/hamlit/optimization_test.rb
+++ b/test/hamlit/optimization_test.rb
@@ -9,14 +9,6 @@ describe 'optimization' do
       assert_equal true, compiled_code(haml).include?(%|href='1'|)
     end
 
-    it 'renders a static part of string interpolation statically' do
-      haml = %q|%input{ value: "jruby#{9000}#{dynamic}" }|
-      assert_equal true, compiled_code(haml).include?(%|value='jruby9000|)
-
-      haml = %q|%span= "jruby#{9000}#{dynamic}"|
-      assert_equal true, compiled_code(haml).include?(%|<span>jruby9000|)
-    end
-
     it 'renders static script statically' do
       haml = <<-HAML.unindent
         %span
@@ -28,6 +20,16 @@ describe 'optimization' do
     it 'renders inline static script statically' do
       haml = %|%span= 1|
       assert_equal true, compiled_code(haml).include?(%|<span>1</span>|)
+    end
+  end
+
+  describe 'string interpolation' do
+    it 'renders a static part of string literal statically' do
+      haml = %q|%input{ value: "jruby#{9000}#{dynamic}" }|
+      assert_equal true, compiled_code(haml).include?(%|value='jruby9000|)
+
+      haml = %q|%span= "jruby#{9000}#{dynamic}"|
+      assert_equal true, compiled_code(haml).include?(%|<span>jruby9000|)
     end
   end
 end

--- a/test/hamlit/optimization_test.rb
+++ b/test/hamlit/optimization_test.rb
@@ -32,6 +32,11 @@ describe 'optimization' do
       assert_equal true, compiled_code(haml).include?(%|<span>jruby9000|)
     end
 
+    it 'optimizes script' do
+      haml = %q|= "jruby#{ "#{9000}" }#{dynamic}"|
+      assert_equal true, compiled_code(haml).include?(%|jruby9000|)
+    end
+
     it 'detects a static part recursively' do
       haml = %q|%input{ value: "#{ "hello#{ hello }" }" }|
       assert_equal true, compiled_code(haml).include?(%|value='hello|)

--- a/test/hamlit/optimization_test.rb
+++ b/test/hamlit/optimization_test.rb
@@ -31,5 +31,10 @@ describe 'optimization' do
       haml = %q|%span= "jruby#{9000}#{dynamic}"|
       assert_equal true, compiled_code(haml).include?(%|<span>jruby9000|)
     end
+
+    it 'detects a static part recursively' do
+      haml = %q|%input{ value: "#{ "hello#{ hello }" }" }|
+      assert_equal true, compiled_code(haml).include?(%|value='hello|)
+    end
   end
 end

--- a/test/hamlit/string_splitter_test.rb
+++ b/test/hamlit/string_splitter_test.rb
@@ -1,7 +1,7 @@
-describe Hamlit::StringInterpolation do
+describe Hamlit::StringSplitter do
   describe '.compile' do
     def assert_compile(expected, code)
-      actual = Hamlit::StringInterpolation.compile(code)
+      actual = Hamlit::StringSplitter.compile(code)
       assert_equal expected, actual
     end
 
@@ -27,19 +27,19 @@ describe Hamlit::StringInterpolation do
     describe 'invalid argument' do
       it 'raises internal error' do
         assert_raises Hamlit::InternalError do
-          Hamlit::StringInterpolation.compile('1')
+          Hamlit::StringSplitter.compile('1')
         end
       end
 
       it 'raises internal error' do
         assert_raises Hamlit::InternalError do
-          Hamlit::StringInterpolation.compile('[]')
+          Hamlit::StringSplitter.compile('[]')
         end
       end
 
       it 'raises internal error' do
         assert_raises Hamlit::InternalError do
-          Hamlit::StringInterpolation.compile('"]')
+          Hamlit::StringSplitter.compile('"]')
         end
       end
     end


### PR DESCRIPTION
Refactoring with following changes.

### 	Optimize string interpolation recursively
`%input{ value: "foo#{ "bar#{ baz }" }" }` is optimized recursively