### PR TITLE
Update README.md to clone submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Contributions are welcomed. It'd be good to see
 to learn Temple which is a template engine framework used in Hamlit.
 
 ```bash
-$ git clone https://github.com/k0kubun/hamlit
+$ git clone --recursive https://github.com/k0kubun/hamlit
 $ cd hamlit
 $ bundle install
 


### PR DESCRIPTION
Without cloning submodules `bundle install` will work fine but `bundle exec rake test` will exception. Took me a little while to realise what was going on:

```
$ bundle exec rake test
mkdir -p tmp/x86_64-darwin14/hamlit/2.2.3
cd tmp/x86_64-darwin14/hamlit/2.2.3
/Users/hfaulds/.rbenv/versions/2.2.3/bin/ruby -I. ../../../../ext/hamlit/extconf.rb
creating Makefile
cd -
cd tmp/x86_64-darwin14/hamlit/2.2.3
make
compiling ../../../../ext/hamlit/hamlit.c
../../../../ext/hamlit/hamlit.c:3:10: fatal error: 'houdini.h' file not found
#include "houdini.h"
         ^
1 error generated.
make: *** [hamlit.o] Error 1
rake aborted!
Command failed with status (2): [make...]

Tasks: TOP => test => compile => compile:x86_64-darwin14 => compile:hamlit:x86_64-darwin14 => copy:hamlit:x86_64-darwin14:2.2.3 => tmp/x86_64-d
arwin14/hamlit/2.2.3/hamlit.bundle
(See full trace by running task with --trace)
```