### PR TITLE
fix exe load path

### DIFF
--- a/exe/hamlit
+++ b/exe/hamlit
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-$:.unshift File.expand_path('../lib', __FILE__)
+$:.unshift File.expand_path('../../lib', __FILE__)
 require 'hamlit/cli'
 
 Hamlit::CLI.start(ARGV)


### PR DESCRIPTION
During the development of #60, I fund the bug that the loadpath inside of `exe/hamlit` is wrong.
Before this patch the installed gem is loaded inside the `exe` and not the working copy.