### PR TITLE
Rewrite HTML escape function

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ext/hamlit/houdini"]
-	path = ext/hamlit/houdini
-	url = https://github.com/k0kubun/houdini

--- a/ext/hamlit/extconf.rb
+++ b/ext/hamlit/extconf.rb
@@ -1,18 +1,10 @@
 require 'mkmf'
 
-houdini_dir = File.expand_path('./houdini', __dir__)
-$INCFLAGS << " -I#{houdini_dir}"
-$CFLAGS   << ' -Wall -Wextra'
+$CFLAGS << ' -Wall -Wextra'
 
-$srcs = %w[hamlit.c]
-Dir[File.join(houdini_dir, '*.c')].each do |path|
-  src = File.basename(path)
-  if /mswin|mingw|cygwin|bccwin/ =~ RUBY_PLATFORM
-    FileUtils.cp(path, src)
-  else
-    FileUtils.ln_s(path, src, force: true)
-  end
-  $srcs << src
-end
+$srcs = %w[
+  hamlit.c
+  hescape.c
+]
 
 create_makefile('hamlit/hamlit')

--- a/ext/hamlit/hamlit.c
+++ b/ext/hamlit/hamlit.c
@@ -1,6 +1,6 @@
 #include <ruby.h>
 #include <ruby/encoding.h>
-#include "houdini.h"
+#include "hescape.h"
 #include "string.h"
 
 VALUE mAttributeBuilder, mObjectRef;
@@ -58,13 +58,14 @@ hyphenate(VALUE str)
 static VALUE
 escape_html(VALUE str)
 {
-  gh_buf buf = GH_BUF_INIT;
-
+  char *buf;
+  unsigned int size;
   Check_Type(str, T_STRING);
 
-  if (houdini_escape_html0(&buf, (const uint8_t *)RSTRING_PTR(str), RSTRING_LEN(str), 0)) {
-    str = rb_enc_str_new(buf.ptr, buf.size, rb_utf8_encoding());
-    gh_buf_free(&buf);
+  size = hesc_escape_html(&buf, RSTRING_PTR(str), RSTRING_LEN(str));
+  if (size > RSTRING_LEN(str)) {
+    str = rb_enc_str_new(buf, size, rb_utf8_encoding());
+    free((void *)buf);
   }
 
   return str;

--- a/ext/hamlit/hescape.c
+++ b/ext/hamlit/hescape.c
@@ -78,7 +78,7 @@ hesc_escape_html(char **dest, const char *buf, size_t size)
 
   while (i < size) {
     // Loop here to skip non-escaped characters fast.
-    while (i < size && (esc_i = HTML_ESCAPE_TABLE[(int)buf[i]]) == 0)
+    while (i < size && (esc_i = HTML_ESCAPE_TABLE[(unsigned char)buf[i]]) == 0)
       i++;
 
     if (i < size && esc_i) {

--- a/ext/hamlit/hescape.c
+++ b/ext/hamlit/hescape.c
@@ -1,0 +1,106 @@
+#include <stdio.h>
+#include <string.h>
+#include "hescape.h"
+
+static const uint8_t *ESCAPED_STRING[] = {
+  "",
+  "&quot;",
+  "&amp;",
+  "&#39;",
+  "&lt;",
+  "&gt;",
+};
+
+// This is strlen(ESCAPED_STRING[x]) optimized specially.
+// Mapping: 1 => 6, 2 => 5, 3 => 5, 4 => 4, 5 => 4
+#define ESC_LEN(x) ((13 - x) / 2)
+
+/*
+ * Given ASCII-compatible character, return index of ESCAPED_STRING.
+ *
+ * " (34) => 1 (&quot;)
+ * & (38) => 2 (&amp;)
+ * ' (39) => 3 (&#39;)
+ * < (60) => 4 (&lt;)
+ * > (62) => 5 (&gt;)
+ */
+static const char HTML_ESCAPE_TABLE[] = {
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 1, 0, 0, 0, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 5, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+};
+
+static uint8_t*
+ensure_allocated(uint8_t *buf, size_t size, size_t *asize)
+{
+  if (size < *asize)
+    return buf;
+
+  size_t new_size;
+  if (*asize == 0) {
+    new_size = size;
+  } else {
+    new_size = *asize;
+  }
+
+  // Increase buffer size by 1.5x if realloced multiple times.
+  while (new_size < size)
+    new_size = (new_size << 1) - (new_size >> 1);
+
+  // Round allocation up to multiple of 8.
+  new_size = (new_size + 7) & ~7;
+
+  *asize = new_size;
+  return realloc(buf, new_size);
+}
+
+size_t
+hesc_escape_html(uint8_t **dest, const uint8_t *buf, size_t size)
+{
+  size_t asize = 0, esc_i, esize = 0, i = 0, rbuf_end = 0;
+  const uint8_t *esc;
+  uint8_t *rbuf = NULL;
+
+  while (i < size) {
+    // Loop here to skip non-escaped characters fast.
+    while (i < size && (esc_i = HTML_ESCAPE_TABLE[buf[i]]) == 0)
+      i++;
+
+    if (esc_i) {
+      esc = ESCAPED_STRING[esc_i];
+      rbuf = ensure_allocated(rbuf, sizeof(uint8_t) * (size + esize + ESC_LEN(esc_i) + 1), &asize);
+
+      // Copy pending characters and escaped string.
+      memmove(rbuf + rbuf_end, buf + (rbuf_end - esize), i - (rbuf_end - esize));
+      memmove(rbuf + i + esize, esc, ESC_LEN(esc_i));
+      rbuf_end = i + esize + ESC_LEN(esc_i);
+      esize += ESC_LEN(esc_i) - 1;
+    }
+    i++;
+  }
+
+  if (rbuf_end == 0) {
+    // Return given buf and size if there are no escaped characters.
+    *dest = (uint8_t *)buf;
+    return size;
+  } else {
+    // Copy pending characters including NULL character.
+    memmove(rbuf + rbuf_end, buf + (rbuf_end - esize), (size + 1) - (rbuf_end - esize));
+
+    *dest = rbuf;
+    return size + esize;
+  }
+}

--- a/ext/hamlit/hescape.c
+++ b/ext/hamlit/hescape.c
@@ -1,8 +1,9 @@
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include "hescape.h"
 
-static const uint8_t *ESCAPED_STRING[] = {
+static const char *ESCAPED_STRING[] = {
   "",
   "&quot;",
   "&amp;",
@@ -43,13 +44,14 @@ static const char HTML_ESCAPE_TABLE[] = {
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 
-static uint8_t*
-ensure_allocated(uint8_t *buf, size_t size, size_t *asize)
+static char*
+ensure_allocated(char *buf, size_t size, size_t *asize)
 {
+  size_t new_size;
+
   if (size < *asize)
     return buf;
 
-  size_t new_size;
   if (*asize == 0) {
     new_size = size;
   } else {
@@ -68,20 +70,20 @@ ensure_allocated(uint8_t *buf, size_t size, size_t *asize)
 }
 
 size_t
-hesc_escape_html(uint8_t **dest, const uint8_t *buf, size_t size)
+hesc_escape_html(char **dest, const char *buf, size_t size)
 {
   size_t asize = 0, esc_i, esize = 0, i = 0, rbuf_end = 0;
-  const uint8_t *esc;
-  uint8_t *rbuf = NULL;
+  const char *esc;
+  char *rbuf = NULL;
 
   while (i < size) {
     // Loop here to skip non-escaped characters fast.
-    while (i < size && (esc_i = HTML_ESCAPE_TABLE[buf[i]]) == 0)
+    while (i < size && (esc_i = HTML_ESCAPE_TABLE[(int)buf[i]]) == 0)
       i++;
 
-    if (esc_i) {
+    if (i < size && esc_i) {
       esc = ESCAPED_STRING[esc_i];
-      rbuf = ensure_allocated(rbuf, sizeof(uint8_t) * (size + esize + ESC_LEN(esc_i) + 1), &asize);
+      rbuf = ensure_allocated(rbuf, sizeof(char) * (size + esize + ESC_LEN(esc_i) + 1), &asize);
 
       // Copy pending characters and escaped string.
       memmove(rbuf + rbuf_end, buf + (rbuf_end - esize), i - (rbuf_end - esize));
@@ -94,7 +96,7 @@ hesc_escape_html(uint8_t **dest, const uint8_t *buf, size_t size)
 
   if (rbuf_end == 0) {
     // Return given buf and size if there are no escaped characters.
-    *dest = (uint8_t *)buf;
+    *dest = (char *)buf;
     return size;
   } else {
     // Copy pending characters including NULL character.

--- a/ext/hamlit/hescape.h
+++ b/ext/hamlit/hescape.h
@@ -1,0 +1,21 @@
+#ifndef HESCAPE_H
+#define HESCAPE_H
+
+#include <sys/types.h>
+#include <stdint.h>
+
+/*
+ * Replace characters according to the following rules.
+ * Note that this function can handle only ASCII-compatible string.
+ *
+ * " => &quot;
+ * & => &amp;
+ * ' => &#39;
+ * < => &lt;
+ * > => &gt;
+ *
+ * @return size of dest. If it's larger than len, dest is required to be freed.
+ */
+extern size_t hesc_escape_html(uint8_t **dest, const uint8_t *src, size_t size);
+
+#endif

--- a/ext/hamlit/hescape.h
+++ b/ext/hamlit/hescape.h
@@ -2,7 +2,6 @@
 #define HESCAPE_H
 
 #include <sys/types.h>
-#include <stdint.h>
 
 /*
  * Replace characters according to the following rules.
@@ -16,6 +15,6 @@
  *
  * @return size of dest. If it's larger than len, dest is required to be freed.
  */
-extern size_t hesc_escape_html(uint8_t **dest, const uint8_t *src, size_t size);
+extern size_t hesc_escape_html(char **dest, const char *src, size_t size);
 
 #endif

--- a/hamlit.gemspec
+++ b/hamlit.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/k0kubun/hamlit'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|sample)/}) } + `git -C ext/hamlit/houdini ls-files -z`.split("\x0").map { |path| "ext/hamlit/houdini/#{path}" }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|sample)/}) }
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.extensions    = ['ext/hamlit/extconf.rb']


### PR DESCRIPTION
Drop houdini from dependency and stop using submodule. It'll release us from build issues on windows https://github.com/k0kubun/hamlit/issues/69 and packaging problems https://github.com/k0kubun/hamlit/issues/79. Since they are almost the same, it won't affect performance. Just for maintainability.