### PR TITLE
Declare frozen_string_literal pragma

### DIFF
--- a/lib/hamlit.rb
+++ b/lib/hamlit.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit/engine'
 require 'hamlit/error'
 require 'hamlit/version'

--- a/lib/hamlit/attribute_builder.rb
+++ b/lib/hamlit/attribute_builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit/hamlit'
 require 'hamlit/object_ref'
 require 'hamlit/utils'

--- a/lib/hamlit/attribute_compiler.rb
+++ b/lib/hamlit/attribute_compiler.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit/attribute_builder'
 require 'hamlit/attribute_parser'
 require 'hamlit/ruby_expression'
@@ -41,11 +42,11 @@ module Hamlit
         values.select! { |_, exp| exp != nil }
 
         case key
-        when 'id'.freeze
+        when 'id'
           compile_id!(temple, key, values)
-        when 'class'.freeze
+        when 'class'
           compile_class!(temple, key, values)
-        when 'data'.freeze
+        when 'data'
           compile_data!(temple, key, values)
         when *AttributeBuilder::BOOLEAN_ATTRIBUTES, /\Adata-/
           compile_boolean!(temple, key, values)

--- a/lib/hamlit/attribute_parser.rb
+++ b/lib/hamlit/attribute_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit/ruby_expression'
 
 module Hamlit
@@ -28,8 +29,8 @@ module Hamlit
 
     def wrap_bracket(text)
       text = text.strip
-      return text if text[0] == '{'.freeze
-      '{' << text << '}'.freeze
+      return text if text[0] == '{'
+      "{#{text}}"
     end
 
     def parse_key!(tokens)
@@ -38,10 +39,10 @@ module Hamlit
       when :on_sp
         parse_key!(tokens)
       when :on_label
-        str.tr(':'.freeze, ''.freeze)
+        str.tr(':', '')
       when :on_symbeg
         _, _, key = tokens.shift
-        assert_type!(tokens.shift, :on_tstring_end) if str != ':'.freeze
+        assert_type!(tokens.shift, :on_tstring_end) if str != ':'
         skip_until_hash_rocket!(tokens)
         key
       when :on_tstring_beg
@@ -64,7 +65,7 @@ module Hamlit
     def skip_until_hash_rocket!(tokens)
       until tokens.empty?
         _, type, str = tokens.shift
-        break if type == :on_op && str == '=>'.freeze
+        break if type == :on_op && str == '=>'
       end
     end
 

--- a/lib/hamlit/cli.rb
+++ b/lib/hamlit/cli.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit'
 require 'thor'
 

--- a/lib/hamlit/compiler.rb
+++ b/lib/hamlit/compiler.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit/compiler/children_compiler'
 require 'hamlit/compiler/comment_compiler'
 require 'hamlit/compiler/doctype_compiler'

--- a/lib/hamlit/compiler/children_compiler.rb
+++ b/lib/hamlit/compiler/children_compiler.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   class Compiler
     class ChildrenCompiler
@@ -101,7 +102,7 @@ module Hamlit
         when :script
           node.children.empty? && !nuke_inner_whitespace?(node)
         when :filter
-          !%w[ruby].freeze.include?(node.value[:name])
+          !%w[ruby].include?(node.value[:name])
         else
           false
         end

--- a/lib/hamlit/compiler/doctype_compiler.rb
+++ b/lib/hamlit/compiler/doctype_compiler.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   class Compiler
     class DoctypeCompiler

--- a/lib/hamlit/compiler/script_compiler.rb
+++ b/lib/hamlit/compiler/script_compiler.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit/ruby_expression'
 require 'hamlit/static_analyzer'
 require 'hamlit/string_splitter'
@@ -69,7 +70,7 @@ module Hamlit
           [:multi,
            [:code, "#{var} = (#{node.value[:text]}"],
            [:newline],
-           [:code, ')'.freeze],
+           [:code, ')'],
           ]
         else
           [:multi,
@@ -84,7 +85,7 @@ module Hamlit
         if !node.value[:escape_html] && node.value[:preserve]
           result = find_and_preserve(result)
         else
-          result = '(' << result << ').to_s'.freeze
+          result = "(#{result}).to_s"
         end
         [:escape, node.value[:escape_html], [:dynamic, result]]
       end

--- a/lib/hamlit/compiler/silent_script_compiler.rb
+++ b/lib/hamlit/compiler/silent_script_compiler.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   class Compiler
     class SilentScriptCompiler

--- a/lib/hamlit/compiler/tag_compiler.rb
+++ b/lib/hamlit/compiler/tag_compiler.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit/parser/haml_util'
 require 'hamlit/attribute_compiler'
 require 'hamlit/static_analyzer'
@@ -35,7 +36,7 @@ module Hamlit
           [:multi,
            [:code, "#{var} = (#{node.value[:value]}"],
            [:newline],
-           [:code, ')'.freeze],
+           [:code, ')'],
            [:escape, node.value[:escape_html], [:dynamic, var]]
           ]
         else

--- a/lib/hamlit/engine.rb
+++ b/lib/hamlit/engine.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'temple'
 require 'hamlit/parser'
 require 'hamlit/compiler'

--- a/lib/hamlit/error.rb
+++ b/lib/hamlit/error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   class Error < StandardError
     attr_reader :line

--- a/lib/hamlit/escapable.rb
+++ b/lib/hamlit/escapable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit/utils'
 
 module Hamlit

--- a/lib/hamlit/filters.rb
+++ b/lib/hamlit/filters.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit/filters/base'
 require 'hamlit/filters/text_base'
 require 'hamlit/filters/tilt_base'

--- a/lib/hamlit/filters/base.rb
+++ b/lib/hamlit/filters/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit/parser/haml_util'
 
 module Hamlit

--- a/lib/hamlit/filters/cdata.rb
+++ b/lib/hamlit/filters/cdata.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   class Filters
     class Cdata < TextBase
@@ -9,9 +10,9 @@ module Hamlit
 
       def compile_cdata(node)
         temple = [:multi]
-        temple << [:static, "<![CDATA[\n".freeze]
-        compile_text!(temple, node, '    '.freeze)
-        temple << [:static, "\n]]>".freeze]
+        temple << [:static, "<![CDATA[\n"]
+        compile_text!(temple, node, '    ')
+        temple << [:static, "\n]]>"]
         temple
       end
     end

--- a/lib/hamlit/filters/coffee.rb
+++ b/lib/hamlit/filters/coffee.rb
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 module Hamlit
   class Filters
     class Coffee < TiltBase
       def compile(node)
         require 'tilt/coffee' if explicit_require?
         temple = [:multi]
-        temple << [:static, "<script>\n".freeze]
+        temple << [:static, "<script>\n"]
         temple << compile_with_tilt(node, 'coffee', indent_width: 2)
-        temple << [:static, "</script>".freeze]
+        temple << [:static, "</script>"]
         temple
       end
     end

--- a/lib/hamlit/filters/css.rb
+++ b/lib/hamlit/filters/css.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   class Filters
     class Css < TextBase
@@ -14,17 +15,17 @@ module Hamlit
 
       def compile_html(node)
         temple = [:multi]
-        temple << [:static, "<style>\n".freeze]
-        compile_text!(temple, node, '  '.freeze)
-        temple << [:static, "\n</style>".freeze]
+        temple << [:static, "<style>\n"]
+        compile_text!(temple, node, '  ')
+        temple << [:static, "\n</style>"]
         temple
       end
 
       def compile_xhtml(node)
         temple = [:multi]
-        temple << [:static, "<style type='text/css'>\n  /*<![CDATA[*/\n".freeze]
-        compile_text!(temple, node, '    '.freeze)
-        temple << [:static, "\n  /*]]>*/\n</style>".freeze]
+        temple << [:static, "<style type='text/css'>\n  /*<![CDATA[*/\n"]
+        compile_text!(temple, node, '    ')
+        temple << [:static, "\n  /*]]>*/\n</style>"]
         temple
       end
     end

--- a/lib/hamlit/filters/erb.rb
+++ b/lib/hamlit/filters/erb.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   class Filters
     class Erb < TiltBase

--- a/lib/hamlit/filters/escaped.rb
+++ b/lib/hamlit/filters/escaped.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   class Filters
     class Escaped < Base

--- a/lib/hamlit/filters/javascript.rb
+++ b/lib/hamlit/filters/javascript.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   class Filters
     class Javascript < TextBase
@@ -14,17 +15,17 @@ module Hamlit
 
       def compile_html(node)
         temple = [:multi]
-        temple << [:static, "<script>\n".freeze]
-        compile_text!(temple, node, '  '.freeze)
-        temple << [:static, "\n</script>".freeze]
+        temple << [:static, "<script>\n"]
+        compile_text!(temple, node, '  ')
+        temple << [:static, "\n</script>"]
         temple
       end
 
       def compile_xhtml(node)
         temple = [:multi]
-        temple << [:static, "<script type='text/javascript'>\n  //<![CDATA[\n".freeze]
-        compile_text!(temple, node, '    '.freeze)
-        temple << [:static, "\n  //]]>\n</script>".freeze]
+        temple << [:static, "<script type='text/javascript'>\n  //<![CDATA[\n"]
+        compile_text!(temple, node, '    ')
+        temple << [:static, "\n  //]]>\n</script>"]
         temple
       end
     end

--- a/lib/hamlit/filters/less.rb
+++ b/lib/hamlit/filters/less.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # LESS support is deprecated since it requires therubyracer.gem,
 # which is hard to maintain.
 #
@@ -9,9 +10,9 @@ module Hamlit
       def compile(node)
         require 'tilt/less' if explicit_require?
         temple = [:multi]
-        temple << [:static, "<style>\n".freeze]
+        temple << [:static, "<style>\n"]
         temple << compile_with_tilt(node, 'less', indent_width: 2)
-        temple << [:static, "</style>".freeze]
+        temple << [:static, '</style>']
         temple
       end
     end

--- a/lib/hamlit/filters/plain.rb
+++ b/lib/hamlit/filters/plain.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit/string_splitter'
 
 module Hamlit

--- a/lib/hamlit/filters/preserve.rb
+++ b/lib/hamlit/filters/preserve.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   class Filters
     class Preserve < Base

--- a/lib/hamlit/filters/ruby.rb
+++ b/lib/hamlit/filters/ruby.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   class Filters
     class Ruby < Base

--- a/lib/hamlit/filters/sass.rb
+++ b/lib/hamlit/filters/sass.rb
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 module Hamlit
   class Filters
     class Sass < TiltBase
       def compile(node)
         require 'tilt/sass' if explicit_require?
         temple = [:multi]
-        temple << [:static, "<style>\n".freeze]
+        temple << [:static, "<style>\n"]
         temple << compile_with_tilt(node, 'sass', indent_width: 2)
-        temple << [:static, "</style>".freeze]
+        temple << [:static, "</style>"]
         temple
       end
     end

--- a/lib/hamlit/filters/scss.rb
+++ b/lib/hamlit/filters/scss.rb
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 module Hamlit
   class Filters
     class Scss < TiltBase
       def compile(node)
         require 'tilt/sass' if explicit_require?
         temple = [:multi]
-        temple << [:static, "<style>\n".freeze]
+        temple << [:static, "<style>\n"]
         temple << compile_with_tilt(node, 'scss', indent_width: 2)
-        temple << [:static, "</style>".freeze]
+        temple << [:static, "</style>"]
         temple
       end
     end

--- a/lib/hamlit/filters/text_base.rb
+++ b/lib/hamlit/filters/text_base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   class Filters
     class TextBase < Base

--- a/lib/hamlit/filters/tilt_base.rb
+++ b/lib/hamlit/filters/tilt_base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'tilt'
 
 module Hamlit
@@ -6,7 +7,7 @@ module Hamlit
       def self.render(name, source, indent_width: 0)
         text = ::Tilt["t.#{name}"].new { source }.render
         return text if indent_width == 0
-        text.gsub!(/^/, ' '.freeze * indent_width)
+        text.gsub!(/^/, ' ' * indent_width)
       end
 
       def explicit_require?

--- a/lib/hamlit/force_escapable.rb
+++ b/lib/hamlit/force_escapable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit/escapable'
 
 module Hamlit

--- a/lib/hamlit/helpers.rb
+++ b/lib/hamlit/helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   module Helpers
     extend self

--- a/lib/hamlit/html.rb
+++ b/lib/hamlit/html.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   class HTML < Temple::HTML::Fast
     DEPRECATED_FORMATS = %i[html4 html5].freeze

--- a/lib/hamlit/identity.rb
+++ b/lib/hamlit/identity.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   class Identity
     def initialize

--- a/lib/hamlit/object_ref.rb
+++ b/lib/hamlit/object_ref.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   module ObjectRef
     class << self

--- a/lib/hamlit/parser.rb
+++ b/lib/hamlit/parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Hamlit::Parser uses original Haml::Parser to generate Haml AST.
 # hamlit/parser/haml_* are modules originally in haml gem.
 

--- a/lib/hamlit/rails_helpers.rb
+++ b/lib/hamlit/rails_helpers.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 require 'hamlit/helpers'
 
 # Currently this Hamlit::Helpers depends on

--- a/lib/hamlit/rails_helpers.rb
+++ b/lib/hamlit/rails_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit/helpers'
 
 # Currently this Hamlit::Helpers depends on

--- a/lib/hamlit/rails_template.rb
+++ b/lib/hamlit/rails_template.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'temple'
 require 'hamlit/engine'
 require 'hamlit/rails_helpers'

--- a/lib/hamlit/railtie.rb
+++ b/lib/hamlit/railtie.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails'
 
 module Hamlit

--- a/lib/hamlit/ruby_expression.rb
+++ b/lib/hamlit/ruby_expression.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'ripper'
 
 module Hamlit

--- a/lib/hamlit/static_analyzer.rb
+++ b/lib/hamlit/static_analyzer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit/ruby_expression'
 
 module Hamlit

--- a/lib/hamlit/template.rb
+++ b/lib/hamlit/template.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'temple'
 require 'hamlit/engine'
 require 'hamlit/helpers'

--- a/lib/hamlit/template.rb
+++ b/lib/hamlit/template.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 require 'temple'
 require 'hamlit/engine'
 require 'hamlit/helpers'

--- a/lib/hamlit/utils.rb
+++ b/lib/hamlit/utils.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hamlit/hamlit'
 
 module Hamlit

--- a/lib/hamlit/version.rb
+++ b/lib/hamlit/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hamlit
   VERSION = '2.6.1'
 end


### PR DESCRIPTION
Hamlit is using frozen string literal in its source code to optimize compilation.
Since Ruby 2.3 may be widely used now, I prefer `frozen_string_literal: true` rather than appending `.freeze` to all string literals.