### PR TITLE
ActiveSupport::SafeBuffer replaced by ActionView::OutputBuffer...

### DIFF
--- a/lib/hamlit/rails_template.rb
+++ b/lib/hamlit/rails_template.rb
@@ -8,7 +8,7 @@ require 'hamlit/parser/haml_util'
 module Hamlit
   RailsTemplate = Temple::Templates::Rails.create(
     Hamlit::Engine,
-    generator:     Temple::Generators::RailsOutputBuffer,
+    generator:     Temple::Generators::RailsOutputBuffer.new(buffer_class: 'ActionView::OutputBuffer'),
     register_as:   :haml,
     use_html_safe: true,
     streaming:     true,

--- a/test/hamlit/rails_template_test.rb
+++ b/test/hamlit/rails_template_test.rb
@@ -144,4 +144,8 @@ describe Hamlit::RailsTemplate do
     assert_equal %Q|<hr>\n|, render(%q|= ::TosSafeObject.new|)
     assert_equal %Q|&lt;hr&gt;\n|, render(%q|= ::TosUnsafeObject.new|)
   end
+
+  specify 'encoding' do
+    assert_equal Encoding.default_external, render('Test').encoding
+  end
 end


### PR DESCRIPTION
…in rails template in order to fix string encoding