### PR TITLE
add `download` as BOOLEAN_ATTRIBUTE for anchors

### DIFF
--- a/lib/hamlit/attribute_builder.rb
+++ b/lib/hamlit/attribute_builder.rb
@@ -9,5 +9,5 @@ module Hamlit::AttributeBuilder
                        defer reversed ismap seamless muted required
                        autofocus novalidate formnovalidate open pubdate
                        itemscope allowfullscreen default inert sortable
-                       truespeed typemustmatch].freeze
+                       truespeed typemustmatch download].freeze
 end


### PR DESCRIPTION
Tiny change, adds `download` for anchor tags, as [described in MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download).