### PR TITLE
make `hamlit compile -` to read things from stdin

### DIFF
--- a/lib/hamlit/cli.rb
+++ b/lib/hamlit/cli.rb
@@ -56,7 +56,7 @@ module Hamlit
     end
 
     def generate_code(file)
-      template = File.read(file)
+      template = file == '-' ? STDIN.read : File.read(file)
       if options[:actionview]
         require 'action_view'
         require 'action_view/base'


### PR DESCRIPTION
In UNIX convention, `-` means STDIN, and it is sometimes useful, e.g. use in other toolchains via pipelines (`x foo.haml | preprocessor | hamlit compile -`).