### PR TITLE
upgrading to Tilt 2 forces specific interpreter usage

### DIFF
--- a/lib/hamlit/filters/coffee.rb
+++ b/lib/hamlit/filters/coffee.rb
@@ -3,7 +3,7 @@ module Hamlit
   class Filters
     class Coffee < TiltBase
       def compile(node)
-        require 'tilt/coffee' if explicit_require?
+        require 'tilt/coffee' if explicit_require?('coffee')
         temple = [:multi]
         temple << [:static, "<script>\n"]
         temple << compile_with_tilt(node, 'coffee', indent_width: 2)

--- a/lib/hamlit/filters/less.rb
+++ b/lib/hamlit/filters/less.rb
@@ -8,7 +8,7 @@ module Hamlit
   class Filters
     class Less < TiltBase
       def compile(node)
-        require 'tilt/less' if explicit_require?
+        require 'tilt/less' if explicit_require?('less')
         temple = [:multi]
         temple << [:static, "<style>\n"]
         temple << compile_with_tilt(node, 'less', indent_width: 2)

--- a/lib/hamlit/filters/markdown.rb
+++ b/lib/hamlit/filters/markdown.rb
@@ -2,7 +2,7 @@ module Hamlit
   class Filters
     class Markdown < TiltBase
       def compile(node)
-        require 'tilt/redcarpet' if explicit_require?
+        require 'tilt/redcarpet' if explicit_require?('markdown')
         compile_with_tilt(node, 'markdown')
       end
     end

--- a/lib/hamlit/filters/sass.rb
+++ b/lib/hamlit/filters/sass.rb
@@ -3,7 +3,7 @@ module Hamlit
   class Filters
     class Sass < TiltBase
       def compile(node)
-        require 'tilt/sass' if explicit_require?
+        require 'tilt/sass' if explicit_require?('sass')
         temple = [:multi]
         temple << [:static, "<style>\n"]
         temple << compile_with_tilt(node, 'sass', indent_width: 2)

--- a/lib/hamlit/filters/scss.rb
+++ b/lib/hamlit/filters/scss.rb
@@ -3,7 +3,7 @@ module Hamlit
   class Filters
     class Scss < TiltBase
       def compile(node)
-        require 'tilt/sass' if explicit_require?
+        require 'tilt/sass' if explicit_require?('scss')
         temple = [:multi]
         temple << [:static, "<style>\n"]
         temple << compile_with_tilt(node, 'scss', indent_width: 2)

--- a/lib/hamlit/filters/tilt_base.rb
+++ b/lib/hamlit/filters/tilt_base.rb
@@ -10,8 +10,9 @@ module Hamlit
         text.gsub!(/^/, ' ' * indent_width)
       end
 
-      def explicit_require?
-        Gem::Version.new(Tilt::VERSION) >= Gem::Version.new('2.0.0')
+      def explicit_require?(needed_registration)
+        Gem::Version.new(Tilt::VERSION) >= Gem::Version.new('2.0.0') &&
+          !Tilt.registered?(needed_registration)
       end
 
       private


### PR DESCRIPTION
I use Kramdown for markdown rendering.
When I upgraded to Tilt 2, Hamlit started trying to require redcarpet.

This change should make it so that redcarpet (And other engines) are only registered when Tilt doesn't already have another engine registered.