### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ If you want to use view generator, consider using [hamlit-rails](https://github.
 ### Sinatra
 
 Replace `gem "haml"` with `gem "hamlit"` in Gemfile, and require "hamlit".
-See [sample/sinatra](sample/sinatra) for working sample.
 
 While Haml disables `escape_html` option by default, Hamlit enables it for security.
 If you want to disable it, please write:


### PR DESCRIPTION
`sample/sinatra` dir was [dropped](https://github.com/k0kubun/hamlit/commit/0b91d0e8eff24c5a5342b5f5d1ccb0411b707014), so `README.md` should be fixed to avoid confusion.