### PR TITLE
Fix deprecation warning on Rails 6

### DIFF
--- a/lib/hamlit/rails_template.rb
+++ b/lib/hamlit/rails_template.rb
@@ -23,7 +23,8 @@ module Hamlit
       end
     end
 
-    def call(template)
+    def call(template, source = nil)
+      source ||= template.source
       options = RailsTemplate.options
 
       # https://github.com/haml/haml/blob/4.0.7/lib/haml/template/plugin.rb#L19-L20
@@ -32,7 +33,7 @@ module Hamlit
         options = options.merge(format: :xhtml)
       end
 
-      Engine.new(options).call(template.source)
+      Engine.new(options).call(source)
     end
 
     def supports_streaming?


### PR DESCRIPTION
When trying rails 6.0.0.beta3 with hamlit 2.9.2, I found a following deprecation warning:

```
DEPRECATION WARNING: Single arity template handlers are deprecated.  Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> Hamlit::RailsTemplate#call(template)
To:
  >> Hamlit::RailsTemplate#call(template, source)
```

This pull request brings hamlit template handler up to work with Rails 6 and no deprecation warnings.

See also:

- https://github.com/rails/rails/pull/35119
- https://github.com/haml/haml/pull/1008
- https://github.com/rails/coffee-rails/pull/101
- https://github.com/rails/jbuilder/pull/453
