### PR TITLE
adds Ruby 3.0 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
           - ruby:2.5
           - ruby:2.6
           - ruby:2.7
+          - ruby:3.0
           # TODO: add jruby and truffleruby
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Thanks for the gem!

All specs are passing locally on Ruby 3 (ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin19])
```
Finished in 4.189119s, 259.2431 runs/s, 277.8627 assertions/s.
1086 runs, 1164 assertions, 0 failures, 0 errors, 203 skips
```