### PR TITLE
Use GitHub action cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,7 @@ jobs:
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-${{ matrix.ruby }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
+          restore-keys: ${{ runner.os }}-gems-
       - run: apt-get update && apt-get install -y nodejs # For execjs
       - name: bundle install
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,5 @@ jobs:
           restore-keys: ${{ runner.os }}-gems-
       - run: apt-get update && apt-get install -y nodejs # For execjs
       - name: bundle install
-        run: bundle install --path vendor/bundle -j$(nproc) --retry 3
+        run: bundle config path vendor/bundle && bundle install -j$(nproc) --retry 3
       - run: bundle exec rake test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,5 @@ jobs:
           restore-keys: ${{ runner.os }}-gems-
       - run: apt-get update && apt-get install -y nodejs # For execjs
       - name: bundle install
-        run: |
-          bundle config path vendor/bundle
-          bundle install -j$(nproc) --retry 3
+        run: bundle install --path vendor/bundle -j$(nproc) --retry 3
       - run: bundle exec rake test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,15 @@ jobs:
           # TODO: add jruby and truffleruby
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-${{ matrix.ruby }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
       - run: apt-get update && apt-get install -y nodejs # For execjs
       - name: bundle install
-        run: bundle install -j$(nproc) --retry 3
+        run: |
+          bundle config path vendor/bundle
+          bundle install -j$(nproc) --retry 3
       - run: bundle exec rake test

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,6 @@
 *.bundle
 *.so
 *.su
-*.o
 *.a
+*.o
 *.swp


### PR DESCRIPTION
this should decrease build time for specs by caching installed dependencies

total CI run time without cache: ~ 2min (2.4x)
with cache:  ~ 50sec (1x)