### PR TITLE
Use IRB for colorizing CLI

### DIFF
--- a/lib/hamlit/cli.rb
+++ b/lib/hamlit/cli.rb
@@ -109,12 +109,12 @@ module Hamlit
 
     def puts_code(code, color: true)
       begin
-        require 'pry'
+        require 'irb/color'
       rescue LoadError
         color = false
       end
       if color
-        puts Pry.Code(code).highlighted
+        puts IRB::Color.colorize_code(code)
       else
         puts code
       end
@@ -123,12 +123,12 @@ module Hamlit
     # Enable colored pretty printing only for development environment.
     def pp_object(arg, color: true)
       begin
-        require 'pry'
+        require 'irb/color_printer'
       rescue LoadError
         color = false
       end
       if color
-        Pry::ColorPrinter.pp(arg)
+        IRB::ColorPrinter.pp(arg)
       else
         require 'pp'
         pp(arg)


### PR DESCRIPTION
IRB's syntax highlight is based on Ripper, so it gives a better result than Pry.

## Before
![Screenshot from 2021-01-07 22-49-26](https://user-images.githubusercontent.com/3138447/103983797-c29db300-513a-11eb-94eb-a94b783fb933.png)

## After
![Screenshot from 2021-01-07 22-49-47](https://user-images.githubusercontent.com/3138447/103983803-c6313a00-513a-11eb-9e06-fd1617e13ab6.png)