### PR TITLE
Draft: Fix intermittent crashes with GC.compact

### DIFF
--- a/ext/hamlit/hamlit.c
+++ b/ext/hamlit/hamlit.c
@@ -521,9 +521,6 @@ Init_hamlit(void)
   mAttributeBuilder = rb_define_module_under(mHamlit, "AttributeBuilder");
 
   rb_gc_mark(mHamlit);
-  rb_gc_mark(mUtils);
-  rb_gc_mark(mAttributeBuilder);
-  rb_gc_mark(mObjectRef);
 
   rb_define_singleton_method(mUtils, "escape_html", rb_escape_html, 1);
   rb_define_singleton_method(mAttributeBuilder, "build", rb_hamlit_build, -1);

--- a/ext/hamlit/hamlit.c
+++ b/ext/hamlit/hamlit.c
@@ -520,6 +520,11 @@ Init_hamlit(void)
   mUtils            = rb_define_module_under(mHamlit, "Utils");
   mAttributeBuilder = rb_define_module_under(mHamlit, "AttributeBuilder");
 
+  rb_gc_mark(mHamlit);
+  rb_gc_mark(mUtils);
+  rb_gc_mark(mAttributeBuilder);
+  rb_gc_mark(mObjectRef);
+
   rb_define_singleton_method(mUtils, "escape_html", rb_escape_html, 1);
   rb_define_singleton_method(mAttributeBuilder, "build", rb_hamlit_build, -1);
   rb_define_singleton_method(mAttributeBuilder, "build_id", rb_hamlit_build_id, -1);


### PR DESCRIPTION
This fixes the known issue with compaction as described in
https://bugs.ruby-lang.org/issues/15626#Known-Issue.

Since Hamlit holds points to references to VALUE pointers, these
VALUE pointers could move due to compaction. To avoid this, we
pin these objects with `rb_gc_mark`.

I was able to reproduce this issue intermittently via: 

```ruby
# Load a large gem
require 'google/apis'
require 'hamlit'

100.times do
  4.times { GC.start }
  GC.compact

  ::Hamlit::AttributeBuilder.build_class(true, "tab-pane js-toggle-container px-0 pb-0".freeze, 'active')
end
```