### PR TITLE
Ensure the initializer is called before the application's initializers

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -216,7 +216,6 @@ No hyphenation and boolean support. `false` is rendered as "false" (like Rails h
 
 ```rb
 # config/initializers/hamlit.rb or somewhere
-require "hamlit/rails_template"
 Hamlit::RailsTemplate.set_options attr_quote: '"'
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -216,6 +216,7 @@ No hyphenation and boolean support. `false` is rendered as "false" (like Rails h
 
 ```rb
 # config/initializers/hamlit.rb or somewhere
+require "hamlit/rails_template"
 Hamlit::RailsTemplate.set_options attr_quote: '"'
 ```
 

--- a/lib/hamlit/railtie.rb
+++ b/lib/hamlit/railtie.rb
@@ -3,7 +3,7 @@ require 'rails'
 
 module Hamlit
   class Railtie < ::Rails::Railtie
-    initializer :hamlit do |app|
+    initializer :hamlit, before: :load_config_initializers do |app|
       require 'hamlit/rails_template'
     end
   end


### PR DESCRIPTION
In order not to have to `require 'hamlit/rails_template'`, make sure it is called beforehand.

<del>Minor documentation fix that I needed to use `RailsTemplate` in an initializer. (hamlit 2.14.2, hamlit-rails 0.2.3, rails 6.0, Ruby 2.5.7.)</del>