### PR TITLE
Remove requiring 'haml' gem

### DIFF
--- a/lib/hamlit/template.rb
+++ b/lib/hamlit/template.rb
@@ -3,14 +3,6 @@ require 'temple'
 require 'hamlit/engine'
 require 'hamlit/helpers'
 
-# Load tilt/haml first to override if available
-begin
-  require 'haml'
-rescue LoadError
-else
-  require 'tilt/haml'
-end
-
 module Hamlit
   Template = Temple::Templates::Tilt.create(
     Hamlit::Engine,


### PR DESCRIPTION
We have `hamlit` and `haml_lint` specified in the Gemfile:

```ruby
gem 'hamlit', '~> 2.14.4'
gem 'haml_lint', '~> 0.37.0', require: false
```

Even though, `haml_lint` is not required, it's installed along with its dependencies:

```ruby
haml_lint (0.36.0)
  haml (>= 4.0, < 5.3)
  parallel (~> 1.10)
  rainbow
  rubocop (>= 0.50.0)
  sysexits (~> 1.1)
```

Due to [this line](https://github.com/k0kubun/hamlit/blob/f1ba63cf81fd8e7c8a9b735ed179b2eb69d955d2/lib/hamlit/template.rb#L7), the `haml` dependency is loaded, its methods are called and even has some impact on the application behavior. 

I see that `haml` is a [development dependency](https://github.com/k0kubun/hamlit/blob/f1ba63cf81fd8e7c8a9b735ed179b2eb69d955d2/hamlit.gemspec#L37).

When I remove:

```ruby
# Load tilt/haml first to override if available
begin
  require 'haml'
rescue LoadError
else
  require 'tilt/haml'
end
```

The `hamlit` tests still pass. Maybe it can be removed, since `haml` has been removed from `Gemfile`? https://github.com/k0kubun/hamlit/commit/407e785cf36d586bcba7746bfb91bc0d5f275c9e#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55f