### PR TITLE
Add bench to GitHub Actions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,46 @@
+name: bench
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  schedule:
+    - cron: "00 15 * * *" # 7:00 PST (-8), 8:00 PDT (-7)
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - slim: 1
+          - template: 'benchmark/boolean_attribute.haml,benchmark/class_attribute.haml,benchmark/id_attribute.haml,benchmark/data_attribute.haml,benchmark/common_attribute.haml'
+          - template: 'benchmark/dynamic_attributes/boolean_attribute.haml,benchmark/dynamic_attributes/class_attribute.haml,benchmark/dynamic_attributes/id_attribute.haml,benchmark/dynamic_attributes/data_attribute.haml,benchmark/dynamic_attributes/common_attribute.haml'
+          - template: 'benchmark/etc/attribute_builder.haml'
+          - template: 'benchmark/etc/static_analyzer.haml'
+          - template: 'benchmark/etc/string_interpolation.haml'
+          - template: 'test/haml/templates/standard.haml'
+            compile: 1
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-${{ matrix.ruby }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: ${{ runner.os }}-gems-
+      - run: sudo apt-get update && sudo apt-get install -y nodejs libxslt-dev # nodejs for execjs, libxslt for TruffleRuby nokogiri
+      - name: bundle install
+        run: bundle config path vendor/bundle && bundle install -j$(nproc) --retry 3
+      - run: bundle exec rake bench
+        env:
+          SLIM_BENCH: ${{ matrix.slim }}
+          TEMPLATE: ${{ matrix.template }}
+          COMPILE: ${{ matrix.compile }}


### PR DESCRIPTION
Revert benchmark CI  jobs dropped on migration from Travis CI to GitHub Actions in #167.

1. `travis-ci.org` will be shut down in days https://blog.travis-ci.com/2021-05-07-orgshutdown, so we will be able to see the job shown in README: `https://travis-ci.org/github/k0kubun/hamlit/jobs/732178446`.
2. With hamlit 2.15.0, I sometimes saw some performance degradation with uncertain stability in my (unstable) environment (see below), so I will be happy to track the results continuously.

#### Test 1
```
Comparison:
       erubi v1.10.0:   221094.2 i/s
         slim v4.1.0:   217911.3 i/s - 1.01x slower
      hamlit v2.15.0:   181058.4 i/s - 1.22x slower
         faml v0.8.1:   165955.5 i/s - 1.33x slower
         haml v5.2.1:   130652.8 i/s - 1.69x slower
```

#### Test 2
```
Comparison:
      hamlit v2.15.0:   229626.8 i/s
       erubi v1.10.0:   215138.1 i/s - 1.07x slower
         slim v4.1.0:   208698.4 i/s - 1.10x slower
         faml v0.8.1:   187905.2 i/s - 1.22x slower
         haml v5.2.1:   134914.5 i/s - 1.70x slower
```

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>