### PR TITLE
Omit benchmark/ directory from published package

### DIFF
--- a/hamlit.gemspec
+++ b/hamlit.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/k0kubun/hamlit'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|sample)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|sample|benchmark)/}) }
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']


### PR DESCRIPTION
This PR omits `benchmark/` directory from the published package. 


The directory is a bit of large, so this PR reduces network and disk usage.


It reduces 536,576 bytes, about 89%, from the tarball package, which is created by `rake build` command.

```bash
$ du pkg/* --summarize --bytes 
66560	pkg/hamlit-2.15.0.gem-after
603136	pkg/hamlit-2.15.0.gem-before
```


