### PR TITLE
Raise haml error when compile check

### DIFF
--- a/lib/hamlit/cli.rb
+++ b/lib/hamlit/cli.rb
@@ -106,6 +106,7 @@ module Hamlit
       Hamlit::Engine.options.to_h.merge(
         escape_attrs: options[:escape_attrs],
         escape_html:  options[:escape_html],
+        check: options[:check],
       )
     end
 

--- a/lib/hamlit/engine.rb
+++ b/lib/hamlit/engine.rb
@@ -21,6 +21,7 @@ module Hamlit
                        hr img input isindex keygen link menuitem meta
                        param source track wbr),
       filename:     "",
+      check:        false,
     )
 
     use Parser

--- a/lib/hamlit/parser.rb
+++ b/lib/hamlit/parser.rb
@@ -27,6 +27,7 @@ module Hamlit
       AVAILABLE_OPTIONS.each do |key|
         @options[key] = options[key]
       end
+      @check = options[:check]
     end
 
     def call(template)
@@ -35,6 +36,7 @@ module Hamlit
       end
       HamlParser.new(HamlOptions.new(@options)).call(template)
     rescue ::Hamlit::HamlError => e
+      raise e if @check
       error_with_lineno(e)
     end
 


### PR DESCRIPTION
( This Pull Request has been continued from https://github.com/k0kubun/hamlit/pull/188#issuecomment-1028590147 )

raise the error in `Hamlit::Parser` when `hamlit compile -c` to check haml error.

```
$ cat invalid-haml-syntax.haml
%h1
  title
%div
 %span
```

Before this Pull Request

```
$ bundle exec exe/hamlit compile -c invalid-haml-syntax.haml
Syntax OK
$ echo $?
0
```

After this Pull Request

```
$ bundle exec exe/hamlit compile -c invalid-haml-syntax.haml
bundler: failed to load command: exe/hamlit (exe/hamlit)
(haml):4: Inconsistent indentation: 1 space used for indentation, but the rest of the document was indented using 2 spaces. (Hamlit::HamlSyntaxError)
...

$ echo $?
1
```
