### PR TITLE
Support sass-embedded

### DIFF
--- a/lib/hamlit/filters/tilt_base.rb
+++ b/lib/hamlit/filters/tilt_base.rb
@@ -7,7 +7,11 @@ module Hamlit
       def self.render(name, source, indent_width: 0)
         text = ::Tilt["t.#{name}"].new { source }.render
         return text if indent_width == 0
-        text.gsub!(/^/, ' ' * indent_width)
+        if text.frozen?
+          text.gsub(/^/, ' ' * indent_width)
+        else
+          text.gsub!(/^/, ' ' * indent_width)
+        end
       end
 
       def explicit_require?(needed_registration)


### PR DESCRIPTION
Fixes #195.

In sass-embedded, it is protobuf returning frozen string as result. While we could unfreeze it after we get the result in upstream libraries e.g. sass-embedd or tilt, it is intentionally left frozen for best performance. Therefore, this PR updates the code to conditionally use `.gsub` vs `.gsub!`. I did a benchmark locally and it is consistently at least around 5% faster than `(+text).gsub!` on my machine.